### PR TITLE
Additional default classes for form tag

### DIFF
--- a/simple_form.rb
+++ b/simple_form.rb
@@ -142,7 +142,7 @@ SimpleForm.setup do |config|
   #config.label_class = 'control-label'
 
   # You can define the class to use on all forms. Default is simple_form.
-  config.form_class = 'ui form'
+  config.form_class = 'simple_form ui form segment'
 
   # You can define which elements should obtain additional classes
   # config.generate_additional_classes_for = [:wrapper, :label, :input]


### PR DESCRIPTION
I suggest to keep 'simple_form' class to show, that form is generated with simple form, not a default builder (sometimes it is convenient to use default one) and add 'segment' class, because by default forms look prettier with it.
